### PR TITLE
Disable goerr113

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ if [ -n "$INPUT_MODULE_DOWNLOAD_MODE" ]; then
     export MODULE_DOWNLOAD_MODE="--modules-download-mode ${INPUT_MODULE_DOWNLOAD_MODE}"
 fi
 
-golangci-lint run ${MODULE_DOWNLOAD_MODE} --timeout 10m --out-format line-number --enable-all --disable wsl,gochecknoglobals,lll,scopelint,gomnd,funlen,testpackage \
+golangci-lint run ${MODULE_DOWNLOAD_MODE} --timeout 10m --out-format line-number --enable-all --disable wsl,gochecknoglobals,lll,scopelint,gomnd,funlen,testpackage,goerr113 \
   | reviewdog -f=golangci-lint \
       -name="golangci-linter" \
       -reporter="${REPORTER}" \


### PR DESCRIPTION
### What does this PR do?

goerr113 feedbacks has been ignored by most of the team, it disallows you to write `errors.New(..)` which is one of your practice.

I dont think the other checks of this linter are really useful either.


### What are the observable changes?

N/A

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
