### PR TITLE
Update golangci-lint action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ ENV REVIEWDOG_VERSION=v0.11.0
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${REVIEWDOG_VERSION} 
 
 COPY entrypoint.sh /entrypoint.sh
+COPY golangci.yml /golangci.yml
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM golangci/golangci-lint:v1.26
+FROM golangci/golangci-lint:v1.35-alpine
 
-ENV REVIEWDOG_VERSION=v0.10.2
+ENV REVIEWDOG_VERSION=v0.11.0
 
-RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${REVIEWDOG_VERSION}
-
-RUN apt-get install git -y
+RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${REVIEWDOG_VERSION} 
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,19 +4,14 @@ cd "${GITHUB_WORKSPACE}/" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 export FILTER_MODE=added
-export FAILED_ON_ERROR=true
+export FAIL_ON_ERROR=true
 export LEVEL=error
 export REPORTER=github-pr-review
-export MODULE_DOWNLOAD_MODE=""
 
-if [ -n "$INPUT_MODULE_DOWNLOAD_MODE" ]; then
-    export MODULE_DOWNLOAD_MODE="--modules-download-mode ${INPUT_MODULE_DOWNLOAD_MODE}"
-fi
-
-golangci-lint run ${MODULE_DOWNLOAD_MODE} --timeout 10m --out-format line-number --enable-all --disable wsl,gochecknoglobals,lll,scopelint,gomnd,funlen,testpackage,goerr113 \
+golangci-lint run -c /golangci.yml
   | reviewdog -f=golangci-lint \
       -name="golangci-linter" \
       -reporter="${REPORTER}" \
       -filter-mode="${FILTER_MODE}" \
-      -fail-on-error="${FAILED_ON_ERROR}" \
+      -fail-on-error="${FAIL_ON_ERROR}" \
       -level="${LEVEL}"

--- a/golangci.yml
+++ b/golangci.yml
@@ -1,0 +1,29 @@
+run:
+  timeout: 10m
+  tests: true
+  skip-files:
+    - ".*/bindata.go$"
+  modules-download-mode: readonly
+output:
+  format: line-number
+linters:
+  enable-all: true
+  disable:
+    - wsl
+    - gochecknoglobals
+    - lll
+    - scopelint
+    - gomnd
+    - funlen
+    - testpackage
+    - goerr113
+    - wrapcheck
+    - thelper
+    - paralleltest
+    - exhaustivestruct
+    - nlreturn
+    - exhaustive
+    - errorlint
+    - stylecheck
+    - forbidigo
+    - dupl


### PR DESCRIPTION
### What does this PR do ?

This PR: 

- Bumps golangci-lint to v1.35
- Bumps reviewdog to  v0.11.0
- Switch to an alpine image to have a lighter image
- Add a configuration file for golangci-lint, which disables checking migrations directory.