### PR TITLE
upgrade golangci-lint version to 1.51.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: golanci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.50
+        version: v1.51.2
         args: -c ${{ github.action_path }}/.golangci.yml
         only-new-issues: true
 


### PR DESCRIPTION
Quick upgrade from 1.50 version to 1.51.2 to be able to support go on version 1.20