### PR TITLE
Golangci-lint: proposal for more, newer linter, remove godot, add staticcheck as part of the action

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ run:
     - ".*/bindata.go$"
 linters:
   enable:
+    - bodyclose
     - cyclop
     - decorder
     - dupl
@@ -13,23 +14,29 @@ linters:
     - execinquery
     - exportloopref
     - forbidigo
-    # - forcetypeassert
     - funlen
+    - gocheckcompilerdirectives
     - goconst
     - gocritic
     - gocyclo
-    - godot
-    - gofmt
+    - godox
+    - gofumpt
     - goimports
     - gosec
     - misspell
+    - musttag
     - nestif
     - nilnil
+    - nlreturn
     - noctx
+    - nonamedreturns
     - prealloc
     - promlinter
     - reassign
     - revive
+    - tagalign
+    - testifylint
+    - thelper
     - unconvert
     - unparam
     - wastedassign
@@ -38,6 +45,8 @@ linters:
     - wsl
 
   disable:
+    - godot
+    - gofmt # as we have gofumpt
     - golint # as we enabled revive
 
 linters-settings:
@@ -80,6 +89,9 @@ linters-settings:
 
 issues:
   new: true
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  fix: false
 
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,6 @@ inputs:
     description: 'GITHUB_TOKEN.'
     required: true
     default: ${{ github.token }}
-  module_download_mode:
-    description: '-mod=<mode> value'
-    required: false
   go-version:
     description: 'go version'
     required: false
@@ -26,6 +23,8 @@ runs:
         fail_on_error: true
         go_version: ${{ inputs.go-version }}
         filter_mode: added
+    - name: staticcheck
+      uses: dominikh/staticcheck-action@v1.3.0
 
 branding:
   icon: 'check-circle'


### PR DESCRIPTION
- Uses some new linters that can be useful (json tag parsing & presence check, gofumpt instead of gofmt, newlines check, etc)
- Removes godot
- Removes limit of lint warnings per line
- Add staticcheck as part of the action (as the subset uses in golangci-lint is not complete, see [here](https://golangci-lint.run/usage/linters/#enabled-by-default)

This is sure to cause some new warnings and there might be a "getting-used-to-it" period, but we can always switch it all off if needed!