### PR TITLE
golangci.yml: remove gocyclo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,7 +87,6 @@ linters-settings:
 
   cyclop:
     max-complexity: 15
-    skip-tests: true
 
 issues:
   new: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,10 @@ linters-settings:
       - "encoding/*"
       - "gopkg.in/yaml.v2*"
 
+  cyclop:
+    max-complexity: 15
+    skip-tests: true
+
 issues:
   new: true
   max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - gocheckcompilerdirectives
     - goconst
     - gocritic
-    - gocyclo
     - godox
     - gofmt
     - goimports
@@ -42,11 +41,11 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
-
   disable:
     - godot
     - gofumpt # as we have gofmt
     - golint # as we enabled revive
+    - gocyclo 
 
 linters-settings:
   wsl:


### PR DESCRIPTION
- Remove gocyclo as the cyclomatic complexity metric is not necessarily very relevant