### PR TITLE
Allow usage of `http.NewRequest` in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,7 @@ issues:
         - lll
         - funlen
         - nilnil
+        - noctx
     - path: testing.go
       linters:
         - gocyclo
@@ -115,6 +116,7 @@ issues:
         - lll
         - funlen
         - nilnil
+        - noctx
 
     - linters:
         - lll


### PR DESCRIPTION
Because sometimes we don't need `context.Context` at all.

Note: `noctx` is a linter that only checks HTTP requests.