### PR TITLE
golangci.yml: Disable wrapcheck for test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,6 +107,7 @@ issues:
         - funlen
         - nilnil
         - noctx
+        - wrapcheck
     - path: testing.go
       linters:
         - gocyclo
@@ -117,6 +118,7 @@ issues:
         - funlen
         - nilnil
         - noctx
+        - wrapcheck
 
     - linters:
         - lll


### PR DESCRIPTION
I don't think check the error wrapping in test files really matter.