### PR TITLE
misspell: add typos configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,13 @@ linters:
       branch-max-lines: 2
       disable:
         - err
+    misspell:
+      ignore-rules:
+        - publishr
+        - timeserie
+        - ubiquituous
+        - criterias
+        - missbehaving
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
Add ignores to our long lasting typos or idiosyncrasies 